### PR TITLE
WIP: Mqtt API for rico

### DIFF
--- a/incubation/rico-mqtt-client/gradle.properties
+++ b/incubation/rico-mqtt-client/gradle.properties
@@ -1,0 +1,1 @@
+publishJars = false

--- a/incubation/rico-mqtt-client/rico-mqtt-client.gradle
+++ b/incubation/rico-mqtt-client/rico-mqtt-client.gradle
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Karakun AG.
+ * Copyright 2015-2018 Canoo Engineering AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+dependencies {
+    compile project(':rico-client')
+    compile project(':rico-mqtt')
+}

--- a/incubation/rico-mqtt-client/src/main/java/dev/rico/client/mqtt/MqttFactory.java
+++ b/incubation/rico-mqtt-client/src/main/java/dev/rico/client/mqtt/MqttFactory.java
@@ -3,8 +3,17 @@ package dev.rico.client.mqtt;
 import dev.rico.mqtt.MqttClient;
 import dev.rico.mqtt.MqttException;
 
+/**
+ * Factory for {@link MqttClient}
+ */
 public interface MqttFactory {
 
+    /**
+     * Returns a {@link MqttClient} based on the given url.
+     * @param remoteUrl the url of the broker endpoint
+     * @return the client
+     * @throws MqttException if the client can not be created
+     */
     MqttClient getClient(String remoteUrl) throws MqttException;
 
 }

--- a/incubation/rico-mqtt-client/src/main/java/dev/rico/client/mqtt/MqttFactory.java
+++ b/incubation/rico-mqtt-client/src/main/java/dev/rico/client/mqtt/MqttFactory.java
@@ -1,0 +1,10 @@
+package dev.rico.client.mqtt;
+
+import dev.rico.mqtt.MqttClient;
+import dev.rico.mqtt.MqttException;
+
+public interface MqttFactory {
+
+    MqttClient getClient(String remoteUrl) throws MqttException;
+
+}

--- a/incubation/rico-mqtt-client/src/main/java/dev/rico/internal/client/mqtt/MqttFactoryImpl.java
+++ b/incubation/rico-mqtt-client/src/main/java/dev/rico/internal/client/mqtt/MqttFactoryImpl.java
@@ -1,0 +1,24 @@
+package dev.rico.internal.client.mqtt;
+
+import dev.rico.client.Client;
+import dev.rico.client.ClientConfiguration;
+import dev.rico.client.concurrent.UiExecutor;
+import dev.rico.client.mqtt.MqttFactory;
+import dev.rico.core.Configuration;
+import dev.rico.internal.mqtt.MqttClientImpl;
+import dev.rico.mqtt.MqttClient;
+import dev.rico.mqtt.MqttException;
+
+public class MqttFactoryImpl implements MqttFactory {
+
+    private final ClientConfiguration configuration;
+
+    public MqttFactoryImpl(ClientConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public MqttClient getClient(String remoteUrl) throws MqttException {
+        return new MqttClientImpl(remoteUrl, configuration, Client.getService(UiExecutor.class));
+    }
+}

--- a/incubation/rico-mqtt-client/src/main/java/dev/rico/internal/client/mqtt/MqttFactoryImpl.java
+++ b/incubation/rico-mqtt-client/src/main/java/dev/rico/internal/client/mqtt/MqttFactoryImpl.java
@@ -13,12 +13,12 @@ public class MqttFactoryImpl implements MqttFactory {
 
     private final ClientConfiguration configuration;
 
-    public MqttFactoryImpl(ClientConfiguration configuration) {
+    public MqttFactoryImpl(final ClientConfiguration configuration) {
         this.configuration = configuration;
     }
 
     @Override
-    public MqttClient getClient(String remoteUrl) throws MqttException {
+    public MqttClient getClient(final String remoteUrl) throws MqttException {
         return new MqttClientImpl(remoteUrl, configuration, Client.getService(UiExecutor.class));
     }
 }

--- a/incubation/rico-mqtt-client/src/main/java/dev/rico/internal/client/mqtt/MqttServiceProvider.java
+++ b/incubation/rico-mqtt-client/src/main/java/dev/rico/internal/client/mqtt/MqttServiceProvider.java
@@ -1,0 +1,17 @@
+package dev.rico.internal.client.mqtt;
+
+import dev.rico.client.ClientConfiguration;
+import dev.rico.client.mqtt.MqttFactory;
+import dev.rico.internal.client.AbstractServiceProvider;
+
+public class MqttServiceProvider extends AbstractServiceProvider<MqttFactory> {
+
+    public MqttServiceProvider() {
+        super(MqttFactory.class);
+    }
+
+    @Override
+    protected MqttFactory createService(final ClientConfiguration configuration) {
+        return new MqttFactoryImpl(configuration);
+    }
+}

--- a/incubation/rico-mqtt-client/src/main/resources/META-INF/services/dev.rico.client.spi.ServiceProvider
+++ b/incubation/rico-mqtt-client/src/main/resources/META-INF/services/dev.rico.client.spi.ServiceProvider
@@ -1,0 +1,1 @@
+dev.rico.internal.client.mqtt.MqttServiceProvider

--- a/incubation/rico-mqtt-client/src/test/java/DummyTest.java
+++ b/incubation/rico-mqtt-client/src/test/java/DummyTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Karakun AG.
+ * Copyright 2015-2018 Canoo Engineering AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.testng.annotations.Test;
+
+public class DummyTest {
+
+    @Test
+    public void test() {
+
+    }
+
+}

--- a/incubation/rico-mqtt-server/gradle.properties
+++ b/incubation/rico-mqtt-server/gradle.properties
@@ -1,0 +1,1 @@
+publishJars = false

--- a/incubation/rico-mqtt-server/rico-mqtt-server.gradle
+++ b/incubation/rico-mqtt-server/rico-mqtt-server.gradle
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Karakun AG.
+ * Copyright 2015-2018 Canoo Engineering AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+dependencies {
+    compile project(':rico-server')
+    compile project(':rico-mqtt')
+}

--- a/incubation/rico-mqtt-server/src/main/java/dev/rico/internal/server/mqtt/SampleMqttConnectionListener.java
+++ b/incubation/rico-mqtt-server/src/main/java/dev/rico/internal/server/mqtt/SampleMqttConnectionListener.java
@@ -1,0 +1,22 @@
+package dev.rico.internal.server.mqtt;
+
+import dev.rico.mqtt.MqttMessage;
+import dev.rico.server.ServerListener;
+import dev.rico.server.mqtt.MqttConnection;
+import dev.rico.server.mqtt.MqttConnectionListener;
+
+@ServerListener
+public class SampleMqttConnectionListener implements MqttConnectionListener {
+
+    @Override
+    public void onConnected(final MqttConnection connection) {
+        System.out.println("Connection created to mqtt broker with endpoint " + connection.getEndpoint());
+
+        connection.publish("init-topic", MqttMessage.of("Hello broker".getBytes()));
+    }
+
+    @Override
+    public void onDisconnected(final MqttConnection connection) {
+        System.out.println("Disconnected to mqtt broker with endpoint " + connection.getEndpoint());
+    }
+}

--- a/incubation/rico-mqtt-server/src/main/java/dev/rico/internal/server/mqtt/TestController.java
+++ b/incubation/rico-mqtt-server/src/main/java/dev/rico/internal/server/mqtt/TestController.java
@@ -1,0 +1,24 @@
+package dev.rico.internal.server.mqtt;
+
+import dev.rico.mqtt.MqttMessage;
+import dev.rico.server.mqtt.MqttConnection;
+import dev.rico.server.mqtt.MqttController;
+import dev.rico.server.mqtt.MqttSubscription;
+
+@MqttController
+public class TestController {
+
+    private final MqttConnection connection;
+
+    //INJECT
+    public TestController(final MqttConnection connection) {
+        this.connection = connection;
+        connection.publish("initializer", MqttMessage.of("huuh".getBytes()));
+    }
+
+    @MqttSubscription("temp-changed")
+    public void onTemperatureChanged(final MqttMessage message) {
+
+    }
+
+}

--- a/incubation/rico-mqtt-server/src/main/java/dev/rico/server/mqtt/MqttConnection.java
+++ b/incubation/rico-mqtt-server/src/main/java/dev/rico/server/mqtt/MqttConnection.java
@@ -1,0 +1,12 @@
+package dev.rico.server.mqtt;
+
+import dev.rico.mqtt.MqttMessage;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface MqttConnection {
+
+    CompletableFuture<Void> publish(String topic, MqttMessage message);
+
+    String getEndpoint();
+}

--- a/incubation/rico-mqtt-server/src/main/java/dev/rico/server/mqtt/MqttConnectionListener.java
+++ b/incubation/rico-mqtt-server/src/main/java/dev/rico/server/mqtt/MqttConnectionListener.java
@@ -1,0 +1,9 @@
+package dev.rico.server.mqtt;
+
+public interface MqttConnectionListener {
+
+    void onConnected(MqttConnection connection);
+
+    void onDisconnected(MqttConnection connection);
+
+}

--- a/incubation/rico-mqtt-server/src/main/java/dev/rico/server/mqtt/MqttController.java
+++ b/incubation/rico-mqtt-server/src/main/java/dev/rico/server/mqtt/MqttController.java
@@ -1,0 +1,19 @@
+package dev.rico.server.mqtt;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Inherited
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MqttController {
+
+    String broker() default "";
+
+}

--- a/incubation/rico-mqtt-server/src/main/java/dev/rico/server/mqtt/MqttSubscription.java
+++ b/incubation/rico-mqtt-server/src/main/java/dev/rico/server/mqtt/MqttSubscription.java
@@ -1,0 +1,17 @@
+package dev.rico.server.mqtt;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target(ElementType.METHOD)
+public @interface MqttSubscription {
+
+    String value();
+
+}

--- a/incubation/rico-mqtt-server/src/test/java/DummyTest.java
+++ b/incubation/rico-mqtt-server/src/test/java/DummyTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Karakun AG.
+ * Copyright 2015-2018 Canoo Engineering AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.testng.annotations.Test;
+
+public class DummyTest {
+
+    @Test
+    public void test() {
+
+    }
+
+}

--- a/incubation/rico-mqtt/gradle.properties
+++ b/incubation/rico-mqtt/gradle.properties
@@ -1,0 +1,1 @@
+publishJars = false

--- a/incubation/rico-mqtt/rico-mqtt.gradle
+++ b/incubation/rico-mqtt/rico-mqtt.gradle
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Karakun AG.
+ * Copyright 2015-2018 Canoo Engineering AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+dependencies {
+    compile project(':rico-core')
+    compile "org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.0"
+}

--- a/incubation/rico-mqtt/src/main/java/dev/rico/internal/mqtt/MqttClientImpl.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/internal/mqtt/MqttClientImpl.java
@@ -1,0 +1,164 @@
+package dev.rico.internal.mqtt;
+
+import dev.rico.core.Configuration;
+import dev.rico.core.functional.Subscription;
+import dev.rico.internal.core.Assert;
+import dev.rico.mqtt.MqttClient;
+import dev.rico.mqtt.MqttException;
+import dev.rico.mqtt.MqttMessage;
+import dev.rico.mqtt.Qos;
+import org.eclipse.paho.client.mqttv3.IMqttActionListener;
+import org.eclipse.paho.client.mqttv3.IMqttMessageListener;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttPingSender;
+import org.eclipse.paho.client.mqttv3.TimerPingSender;
+import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.BiConsumer;
+
+public class MqttClientImpl implements MqttClient {
+
+    private final MqttAsyncClient internalClient;
+
+    private final MqttConnectOptions connectOptions;
+
+    private final Executor subscriptionCaller;
+
+    public MqttClientImpl(final String serverURI, final Configuration configuration, final Executor subscriptionCaller) throws MqttException {
+        Assert.requireNonNull(configuration, "configuration");
+        this.subscriptionCaller = Assert.requireNonNull(subscriptionCaller, "subscriptionCaller");
+        //TODO: configure based on config
+        connectOptions = new MqttConnectOptions();
+        final String clientId = UUID.randomUUID().toString();
+        final MqttClientPersistence clientPersistence = new MqttDefaultFilePersistence();
+        final MqttPingSender pingSender = new TimerPingSender();
+        final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(10);
+        try {
+            internalClient = new MqttAsyncClient(serverURI, clientId, clientPersistence, pingSender, executorService);
+        } catch (final Exception e) {
+            throw new MqttException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> connect() {
+        final CompletableFuture<Void> result = new CompletableFuture<>();
+        final IMqttActionListener listener = new IMqttActionListener() {
+            @Override
+            public void onSuccess(final IMqttToken asyncActionToken) {
+                result.complete(null);
+            }
+
+            @Override
+            public void onFailure(final IMqttToken asyncActionToken, final Throwable exception) {
+                result.completeExceptionally(exception);
+            }
+        };
+        try {
+            internalClient.connect(connectOptions, null, listener);
+        } catch (final Exception e) {
+            result.completeExceptionally(new MqttException("MQTT error", e));
+        }
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Void> disconnect() {
+        final CompletableFuture<Void> result = new CompletableFuture<>();
+        final IMqttActionListener listener = new IMqttActionListener() {
+            @Override
+            public void onSuccess(final IMqttToken asyncActionToken) {
+                result.complete(null);
+            }
+
+            @Override
+            public void onFailure(final IMqttToken asyncActionToken, final Throwable exception) {
+                result.completeExceptionally(exception);
+            }
+        };
+        try {
+            internalClient.disconnect(null, listener);
+        } catch (Exception e) {
+            result.completeExceptionally(new MqttException("MQTT error", e));
+        }
+        return result;
+    }
+
+    @Override
+    public Optional<String> clientId() {
+        return Optional.ofNullable(internalClient.getClientId());
+    }
+
+    @Override
+    public CompletableFuture<Void> publish(final String topic, final MqttMessage message) {
+        Assert.requireNonNull(message, "message");
+        final CompletableFuture<Void> result = new CompletableFuture<>();
+        final IMqttActionListener listener = new IMqttActionListener() {
+            @Override
+            public void onSuccess(final IMqttToken asyncActionToken) {
+                result.complete(null);
+            }
+
+            @Override
+            public void onFailure(final IMqttToken asyncActionToken, final Throwable exception) {
+                result.completeExceptionally(exception);
+            }
+        };
+        final org.eclipse.paho.client.mqttv3.MqttMessage innerMessage = new org.eclipse.paho.client.mqttv3.MqttMessage();
+        innerMessage.setPayload(message.getPayload());
+        innerMessage.setRetained(message.isRetained());
+        innerMessage.setQos(Qos.toInt(message.getQos()));
+        try {
+            internalClient.publish(topic, innerMessage, null, listener);
+        } catch (final Exception e) {
+            result.completeExceptionally(new MqttException("MQTT error", e));
+        }
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Subscription> subscribe(final String topic, final Qos qos, final BiConsumer<String, MqttMessage> messageListener) {
+        Assert.requireNonNull(messageListener, "messageListener");
+        final CompletableFuture<Subscription> result = new CompletableFuture<>();
+        final IMqttActionListener actionListener = new IMqttActionListener() {
+            @Override
+            public void onSuccess(final IMqttToken asyncActionToken) {
+                result.complete(() -> {
+                    try {
+                        internalClient.unsubscribe(topic);
+                    } catch (final org.eclipse.paho.client.mqttv3.MqttException e) {
+                        throw new RuntimeException("MQQT error", e);
+                    }
+                });
+            }
+
+            @Override
+            public void onFailure(final IMqttToken asyncActionToken, final Throwable exception) {
+                result.completeExceptionally(exception);
+            }
+        };
+        final IMqttMessageListener internalMessageListener = new IMqttMessageListener() {
+            @Override
+            public void messageArrived(final String topic, final org.eclipse.paho.client.mqttv3.MqttMessage message) throws Exception {
+                Assert.requireNonNull(message, "message");
+                final MqttMessage receivedMessage = MqttMessage.of(message.getPayload(), message.isRetained(), Qos.of(message.getQos()));
+                subscriptionCaller.execute(() -> messageListener.accept(topic, receivedMessage));
+            }
+        };
+        try {
+            internalClient.subscribe(topic, Qos.toInt(qos), null, actionListener, internalMessageListener);
+        } catch (final org.eclipse.paho.client.mqttv3.MqttException e) {
+           result.completeExceptionally(new MqttException("MQTT error", e));
+        }
+        return null;
+    }
+}

--- a/incubation/rico-mqtt/src/main/java/dev/rico/internal/mqtt/MqttMessageImpl.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/internal/mqtt/MqttMessageImpl.java
@@ -1,0 +1,47 @@
+package dev.rico.internal.mqtt;
+
+import dev.rico.internal.core.Assert;
+import dev.rico.mqtt.MqttMessage;
+import dev.rico.mqtt.Qos;
+
+public class MqttMessageImpl implements MqttMessage {
+
+    private final byte[] payload;
+
+    private final boolean retained;
+
+    private final Qos qos;
+
+    public MqttMessageImpl(final byte[] payload) {
+        this(payload, false, Qos.Q1);
+    }
+
+    public MqttMessageImpl(final byte[] payload, final boolean retained) {
+        this(payload, retained, Qos.Q1);
+    }
+
+    public MqttMessageImpl(final byte[] payload, final Qos qos) {
+        this(payload, false, qos);
+    }
+
+    public MqttMessageImpl(final byte[] payload, final boolean retained, final Qos qos) {
+        this.payload = Assert.requireNonNull(payload, "payload");
+        this.retained = retained;
+        this.qos = Assert.requireNonNull(qos, "qos");
+    }
+
+    @Override
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    @Override
+    public boolean isRetained() {
+        return retained;
+    }
+
+    @Override
+    public Qos getQos() {
+        return qos;
+    }
+}

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttClient.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttClient.java
@@ -19,4 +19,5 @@ public interface MqttClient {
     CompletableFuture<Void> publish(String topic, MqttMessage message);
 
     CompletableFuture<Subscription> subscribe(String topicFilter, Qos qos, BiConsumer<String, MqttMessage> messageListener);
+
 }

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttClient.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttClient.java
@@ -1,0 +1,22 @@
+package dev.rico.mqtt;
+
+
+import dev.rico.core.functional.Subscription;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+
+public interface MqttClient {
+
+    CompletableFuture<Void> connect();
+
+    CompletableFuture<Void> disconnect();
+
+    //TODO: Do we need this
+    Optional<String> clientId();
+
+    CompletableFuture<Void> publish(String topic, MqttMessage message);
+
+    CompletableFuture<Subscription> subscribe(String topicFilter, Qos qos, BiConsumer<String, MqttMessage> messageListener);
+}

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttClient.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttClient.java
@@ -7,17 +7,38 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
+/**
+ * A mqtt client that can be used to communicate with a mqtt broker
+ */
 public interface MqttClient {
 
+    /**
+     * Connects the client
+     * @return a {@link CompletableFuture} that can be used to observe the connection process
+     */
     CompletableFuture<Void> connect();
 
+    /**
+     * Disconnects the client
+     * @return a {@link CompletableFuture} that can be used to observe the disconnect process
+     */
     CompletableFuture<Void> disconnect();
 
-    //TODO: Do we need this
-    Optional<String> clientId();
-
+    /**
+     * Publish a message to a specific topic
+     * @param topic the topic
+     * @param message the message
+     * @return a {@link CompletableFuture} that can be used to observe the publish process
+     */
     CompletableFuture<Void> publish(String topic, MqttMessage message);
 
+    /**
+     * Subscribes to topics that are defined by the topic filter.
+     * @param topicFilter the topic filter
+     * @param qos he qos
+     * @param messageListener the listener
+     * @return a {@link CompletableFuture} that can be used to observe the subscribe process
+     */
     CompletableFuture<Subscription> subscribe(String topicFilter, Qos qos, BiConsumer<String, MqttMessage> messageListener);
 
 }

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttException.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttException.java
@@ -2,7 +2,7 @@ package dev.rico.mqtt;
 
 public class MqttException extends Exception {
 
-    public MqttException(String message) {
+    public MqttException(final String message) {
         super(message);
     }
 

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttException.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttException.java
@@ -1,15 +1,31 @@
 package dev.rico.mqtt;
 
+/**
+ * General exception for the mqtt module of Rico.
+ */
 public class MqttException extends Exception {
 
+    /**
+     * Constructor
+     * @param message the message
+     */
     public MqttException(final String message) {
         super(message);
     }
 
+    /**
+     * Constructor
+     * @param message the message
+     * @param cause the cause
+     */
     public MqttException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * Constructor
+     * @param cause the cause
+     */
     public MqttException(final Throwable cause) {
         super(cause);
     }

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttException.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttException.java
@@ -6,7 +6,7 @@ public class MqttException extends Exception {
         super(message);
     }
 
-    public MqttException(String message, Throwable cause) {
+    public MqttException(final String message, final Throwable cause) {
         super(message, cause);
     }
 

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttException.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttException.java
@@ -1,0 +1,16 @@
+package dev.rico.mqtt;
+
+public class MqttException extends Exception {
+
+    public MqttException(String message) {
+        super(message);
+    }
+
+    public MqttException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MqttException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttException.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttException.java
@@ -10,7 +10,7 @@ public class MqttException extends Exception {
         super(message, cause);
     }
 
-    public MqttException(Throwable cause) {
+    public MqttException(final Throwable cause) {
         super(cause);
     }
 }

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttMessage.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttMessage.java
@@ -1,0 +1,28 @@
+package dev.rico.mqtt;
+
+import dev.rico.internal.mqtt.MqttMessageImpl;
+
+public interface MqttMessage {
+
+    byte[] getPayload();
+
+    boolean isRetained();
+
+    Qos getQos();
+
+    static MqttMessage of(final byte[] payload) {
+        return new MqttMessageImpl(payload);
+    }
+
+    static MqttMessage of(final byte[] payload, final boolean retained) {
+        return new MqttMessageImpl(payload, retained);
+    }
+
+    static MqttMessage of(final byte[] payload, final Qos qos) {
+        return new MqttMessageImpl(payload, qos);
+    }
+
+    static MqttMessage of(final byte[] payload, final boolean retained, final Qos qos) {
+        return new MqttMessageImpl(payload, retained, qos);
+    }
+}

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttMessage.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/MqttMessage.java
@@ -2,6 +2,9 @@ package dev.rico.mqtt;
 
 import dev.rico.internal.mqtt.MqttMessageImpl;
 
+/**
+ * Definition of a mqtt message.
+ */
 public interface MqttMessage {
 
     byte[] getPayload();

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/Qos.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/Qos.java
@@ -1,13 +1,14 @@
 package dev.rico.mqtt;
 
+import java.util.Objects;
+
+/**
+ * Defines the quality of service (QoS) level. QoS is an agreement between the sender of a message and the receiver of a
+ * message that defines the guarantee of delivery for a specific message. There are 3 QoS levels in MQTT:
+ * At most once (0)
+ * At least once (1)
+ * Exactly once (2).
+ */
 public enum Qos {
     Q0, Q1, Q2;
-
-    public static int toInt(Qos qos) {
-        return -1;
-    }
-
-    public static Qos of(int qos) {
-        return null;
-    }
 }

--- a/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/Qos.java
+++ b/incubation/rico-mqtt/src/main/java/dev/rico/mqtt/Qos.java
@@ -1,0 +1,13 @@
+package dev.rico.mqtt;
+
+public enum Qos {
+    Q0, Q1, Q2;
+
+    public static int toInt(Qos qos) {
+        return -1;
+    }
+
+    public static Qos of(int qos) {
+        return null;
+    }
+}

--- a/incubation/rico-mqtt/src/test/java/DummyTest.java
+++ b/incubation/rico-mqtt/src/test/java/DummyTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Karakun AG.
+ * Copyright 2015-2018 Canoo Engineering AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.testng.annotations.Test;
+
+public class DummyTest {
+
+    @Test
+    public void test() {
+
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,6 +58,8 @@ include 'incubation/rico-crud-jpa'
 include 'incubation/rico-projector-common'
 include 'incubation/rico-projector-client'
 include 'incubation/rico-projector-server'
+include 'incubation/rico-mqtt'
+include 'incubation/rico-mqtt-client'
 
 include 'integration-tests/integration-common'
 include 'integration-tests/integration-server'

--- a/settings.gradle
+++ b/settings.gradle
@@ -60,6 +60,7 @@ include 'incubation/rico-projector-client'
 include 'incubation/rico-projector-server'
 include 'incubation/rico-mqtt'
 include 'incubation/rico-mqtt-client'
+include 'incubation/rico-mqtt-server'
 
 include 'integration-tests/integration-common'
 include 'integration-tests/integration-server'


### PR DESCRIPTION
A first draw of a MQTT API for rico. 

### General module
The general module contains a simple async MQTT client.
The public API is mostly done
For the private API the connection configuration based on a RICO `Configuration` is missing.

### Client module
Do not add any new functionality but integrated the MQTT client in RICO. Based on this a MQTT client can easily created by using the general RICO APIS (`Client.getService(...)`)

### Server module
This module contains only some first ideas how an additional server integration on top of the general client API might look like. Here the idea is to have an API that is similar to the remoting API to make it easy to understand.