### PR TITLE
set javadoc file encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ subprojects { proj ->
     test.useTestNG()
 
     javadoc {
+        options.addStringOption('encoding', 'UTF-8')
         options.addStringOption('Xdoclint:none', '-quiet')
     }
 


### PR DESCRIPTION
set encoding in build condig to avoid build failing with 

> "error: unmappable character for encoding ASCII"