### PR TITLE
Controller parameters

### DIFF
--- a/base/rico-core/src/main/java/dev/rico/internal/core/ReflectionHelper.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/ReflectionHelper.java
@@ -20,6 +20,7 @@ import org.apiguardian.api.API;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -98,6 +99,22 @@ public class ReflectionHelper {
                 }
             }
         });
+    }
+
+    public static <A extends Annotation> Optional<A> getAnnotationOrMetaAnnotation(final Field field, final Class<A> annotationClass) {
+        Assert.requireNonNull(field, "field");
+        Assert.requireNonNull(annotationClass, "annotationClass");
+
+        if(field.isAnnotationPresent(annotationClass)) {
+            return Optional.of(field.getAnnotation(annotationClass));
+        }
+        for(Annotation annotation : field.getAnnotations()) {
+            final Annotation metaAnnotation = annotation.getClass().getAnnotation(annotationClass);
+            if(metaAnnotation != null) {
+                return Optional.of((A) metaAnnotation);
+            }
+        }
+        return Optional.empty();
     }
 
     public static void setPrivileged(final Field field, final Object bean,

--- a/base/rico-core/src/main/java/dev/rico/internal/core/lang/StringUtils.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/lang/StringUtils.java
@@ -1,0 +1,17 @@
+package dev.rico.internal.core.lang;
+
+import java.util.Optional;
+
+public class StringUtils {
+
+    public static Optional<String> nonEmpty(final String s) {
+        if(s == null) {
+            return Optional.empty();
+        }
+        if(s.length() == 0) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(s);
+    }
+
+}

--- a/remoting/rico-remoting-client/src/main/java/dev/rico/client/remoting/ControllerFactory.java
+++ b/remoting/rico-remoting-client/src/main/java/dev/rico/client/remoting/ControllerFactory.java
@@ -18,6 +18,9 @@ package dev.rico.client.remoting;
 
 import org.apiguardian.api.API;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apiguardian.api.API.Status.MAINTAINED;
@@ -36,6 +39,10 @@ public interface ControllerFactory {
      * @param <T> the type of the model that is bound to the controller and view
      * @return a {@link CompletableFuture} that defines the creation of the controller.
      */
-    <T> CompletableFuture<ControllerProxy<T>> createController(String name);
+    default <T> CompletableFuture<ControllerProxy<T>> createController(final String name) {
+        return createController(name, Collections.emptyMap());
+    }
+
+    <T> CompletableFuture<ControllerProxy<T>> createController(final String name, final Map<String, Serializable> parameters);
 
 }

--- a/remoting/rico-remoting-client/src/main/java/dev/rico/internal/client/remoting/ClientContextImpl.java
+++ b/remoting/rico-remoting-client/src/main/java/dev/rico/internal/client/remoting/ClientContextImpl.java
@@ -44,7 +44,9 @@ import dev.rico.client.remoting.ControllerInitalizationException;
 import dev.rico.client.remoting.ControllerProxy;
 import org.apiguardian.api.API;
 
+import java.io.Serializable;
 import java.net.URI;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -105,14 +107,14 @@ public class ClientContextImpl implements ClientContext {
     }
 
     @Override
-    public synchronized <T> CompletableFuture<ControllerProxy<T>> createController(final String name) {
+    public <T> CompletableFuture<ControllerProxy<T>> createController(final String name, final Map<String, Serializable> parameters) {
         Assert.requireNonBlank(name, "name");
 
         if (controllerProxyFactory == null) {
             throw new IllegalStateException("connect was not called!");
         }
 
-        return controllerProxyFactory.<T>create(name).handle((ControllerProxy<T> controllerProxy, Throwable throwable) -> {
+        return controllerProxyFactory.<T>create(name, parameters).handle((ControllerProxy<T> controllerProxy, Throwable throwable) -> {
             if (throwable != null) {
                 throw new ControllerInitalizationException("Error while creating controller of type " + name, throwable);
             }

--- a/remoting/rico-remoting-client/src/main/java/dev/rico/internal/client/remoting/ControllerProxyFactory.java
+++ b/remoting/rico-remoting-client/src/main/java/dev/rico/internal/client/remoting/ControllerProxyFactory.java
@@ -27,6 +27,8 @@ import dev.rico.internal.client.remoting.legacy.ClientModelStore;
 import dev.rico.internal.client.remoting.legacy.communication.AbstractClientConnector;
 import org.apiguardian.api.API;
 
+import java.io.Serializable;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -50,11 +52,11 @@ public class ControllerProxyFactory {
         this.clientConnector = Assert.requireNonNull(clientConnector, "clientConnector");
     }
 
-    public <T> CompletableFuture<ControllerProxy<T>> create(final String name) {
-       return create(name, null);
+    public <T> CompletableFuture<ControllerProxy<T>> create(final String name, final Map<String, Serializable> parameters) {
+       return create(name, null, parameters);
     }
 
-    public <T> CompletableFuture<ControllerProxy<T>> create(final String name, final String parentControllerId) {
+    public <T> CompletableFuture<ControllerProxy<T>> create(final String name, final String parentControllerId, Map<String, Serializable> parameters) {
         Assert.requireNonBlank(name, "name");
         final InternalAttributesBean bean = platformBeanRepository.getInternalAttributesBean();
 
@@ -63,6 +65,7 @@ public class ControllerProxyFactory {
         if(parentControllerId != null) {
             createControllerCommand.setParentControllerId(parentControllerId);
         }
+        createControllerCommand.setParameters(parameters);
 
         return commandHandler.invokeCommand(createControllerCommand).thenApply(new Function<Void, ControllerProxy<T>>() {
             @Override

--- a/remoting/rico-remoting-client/src/main/java/dev/rico/internal/client/remoting/ControllerProxyImpl.java
+++ b/remoting/rico-remoting-client/src/main/java/dev/rico/internal/client/remoting/ControllerProxyImpl.java
@@ -32,6 +32,7 @@ import org.apiguardian.api.API;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -141,10 +142,10 @@ public class ControllerProxyImpl<T> implements ControllerProxy<T> {
     }
 
     @Override
-    public <C> CompletableFuture<ControllerProxy<C>> createController(final String name) {
+    public <C> CompletableFuture<ControllerProxy<C>> createController(final String name, final Map<String, Serializable> parameters) {
         Assert.requireNonBlank(name, "name");
 
-        return controllerProxyFactory.<C>create(name, controllerId).handle((ControllerProxy<C> cControllerProxy, Throwable throwable) -> {
+        return controllerProxyFactory.<C>create(name, controllerId, parameters).handle((ControllerProxy<C> cControllerProxy, Throwable throwable) -> {
             if (throwable != null) {
                 throw new ControllerInitalizationException("Error while creating controller of type " + name, throwable);
             }

--- a/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/codec/JsonPrimitiveTypes.java
+++ b/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/codec/JsonPrimitiveTypes.java
@@ -3,27 +3,36 @@ package dev.rico.internal.remoting.codec;
 import com.google.gson.JsonPrimitive;
 import dev.rico.internal.core.Assert;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
 
 public enum JsonPrimitiveTypes {
 
-    BIG_DECIMAL("BIG_DECIMAL"),
-    BIG_INTEGER("BIG_INTEGER"),
-    BOOLEAN("BOOLEAN"),
-    BYTE("BYTE"),
-    CHARACTER("CHARACTER"),
-    DOUBLE("DOUBLE"),
-    FLOAT("FLOAT"),
-    INT("INT"),
-    LONG("LONG"),
-    SHORT("SHORT"),
-    STRING("STRING");
+    BIG_DECIMAL("BIG_DECIMAL", BigDecimal.class),
+    BIG_INTEGER("BIG_INTEGER", BigInteger.class),
+    BOOLEAN("BOOLEAN", Boolean.class),
+    BYTE("BYTE", Byte.class),
+    CHARACTER("CHARACTER", Character.class),
+    DOUBLE("DOUBLE", Double.class),
+    FLOAT("FLOAT", Float.class),
+    INT("INT", Integer.class),
+    LONG("LONG", Long.class),
+    SHORT("SHORT", Short.class),
+    STRING("STRING", String.class);
 
     private final String type;
 
-    JsonPrimitiveTypes(final String type) {
+    private final Class typeClass;
+
+    JsonPrimitiveTypes(final String type, final Class typeClass) {
         this.type = Assert.requireNonBlank(type, "type");
+        this.typeClass = Assert.requireNonNull(typeClass, "typeClass");
+    }
+
+    public Class getTypeClass() {
+        return typeClass;
     }
 
     public String getType() {
@@ -79,5 +88,13 @@ public enum JsonPrimitiveTypes {
                 .filter(v -> Objects.equals(v.getType(), type))
                 .findAny()
                 .orElseThrow(() -> new IllegalArgumentException("Can not find type '" + type + "'"));
+    }
+
+    public static JsonPrimitiveTypes ofTypeClass(final Class typeClass) {
+        Assert.requireNonNull(typeClass, "typeClass");
+        return Arrays.asList(values()).stream()
+                .filter(v -> Objects.equals(v.getTypeClass(), typeClass))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("Can not find type '" + typeClass + "'"));
     }
 }

--- a/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/codec/JsonPrimitiveTypes.java
+++ b/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/codec/JsonPrimitiveTypes.java
@@ -1,0 +1,83 @@
+package dev.rico.internal.remoting.codec;
+
+import com.google.gson.JsonPrimitive;
+import dev.rico.internal.core.Assert;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public enum JsonPrimitiveTypes {
+
+    BIG_DECIMAL("BIG_DECIMAL"),
+    BIG_INTEGER("BIG_INTEGER"),
+    BOOLEAN("BOOLEAN"),
+    BYTE("BYTE"),
+    CHARACTER("CHARACTER"),
+    DOUBLE("DOUBLE"),
+    FLOAT("FLOAT"),
+    INT("INT"),
+    LONG("LONG"),
+    SHORT("SHORT"),
+    STRING("STRING");
+
+    private final String type;
+
+    JsonPrimitiveTypes(final String type) {
+        this.type = Assert.requireNonBlank(type, "type");
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public <T> T getValueOfElement(final JsonPrimitive element) {
+        Assert.requireNonNull(element, "element");
+
+        if(element.isJsonNull()) {
+            return null;
+        }
+
+        if(Objects.equals(this, BIG_DECIMAL)) {
+            return (T) element.getAsBigDecimal();
+        }
+        if(Objects.equals(this, BIG_INTEGER)) {
+            return (T) element.getAsBigInteger();
+        }
+        if(Objects.equals(this, BOOLEAN)) {
+            return (T) new Boolean(element.getAsBoolean());
+        }
+        if(Objects.equals(this, BYTE)) {
+            return (T) new Byte(element.getAsByte());
+        }
+        if(Objects.equals(this, CHARACTER)) {
+            return (T) new Character(element.getAsCharacter());
+        }
+        if(Objects.equals(this, DOUBLE)) {
+            return (T) new Double(element.getAsDouble());
+        }
+        if(Objects.equals(this, FLOAT)) {
+            return (T) new Float(element.getAsFloat());
+        }
+        if(Objects.equals(this, INT)) {
+            return (T) new Integer(element.getAsInt());
+        }
+        if(Objects.equals(this, LONG)) {
+            return (T) new Long(element.getAsLong());
+        }
+        if(Objects.equals(this, SHORT)) {
+            return (T) new Short(element.getAsShort());
+        }
+        if(Objects.equals(this, STRING)) {
+            return (T) element.getAsString();
+        }
+        throw new IllegalStateException("Type can not be defined!");
+    }
+
+    public static JsonPrimitiveTypes ofType(final String type) {
+        Assert.requireNonBlank(type, "type");
+        return Arrays.asList(values()).stream()
+                .filter(v -> Objects.equals(v.getType(), type))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("Can not find type '" + type + "'"));
+    }
+}

--- a/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/codec/encoders/AbstractCommandTranscoder.java
+++ b/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/codec/encoders/AbstractCommandTranscoder.java
@@ -16,12 +16,25 @@
  */
 package dev.rico.internal.remoting.codec.encoders;
 
-import dev.rico.internal.core.Assert;
-import dev.rico.internal.remoting.legacy.communication.Command;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import dev.rico.internal.core.Assert;
+import dev.rico.internal.remoting.codec.JsonPrimitiveTypes;
+import dev.rico.internal.remoting.legacy.communication.Command;
 import org.apiguardian.api.API;
 
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+import static dev.rico.internal.remoting.legacy.communication.CommandConstants.NAME;
+import static dev.rico.internal.remoting.legacy.communication.CommandConstants.TYPE;
+import static dev.rico.internal.remoting.legacy.communication.CommandConstants.VALUE;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 @API(since = "0.x", status = INTERNAL)
@@ -29,6 +42,72 @@ public abstract class AbstractCommandTranscoder<C extends Command> implements Co
 
     protected boolean isElementJsonNull(final JsonObject jsonObject, final String jsonElementName) {
         return getElement(jsonObject, jsonElementName).isJsonNull();
+    }
+
+    protected JsonArray convertToJsonObject(final Map<String, Serializable> map) {
+        Assert.requireNonNull(map, "map");
+        final JsonArray array = new JsonArray();
+        map.keySet().forEach(key -> {
+            final JsonObject jsonObject = new JsonObject();
+            jsonObject.addProperty(NAME, key);
+            final Object value = map.get(key);
+            if(value == null) {
+                //For NULL we do not care about the type
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.STRING.getType());
+                jsonObject.add(VALUE, JsonNull.INSTANCE);
+            } else if(value instanceof BigDecimal) {
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.BIG_DECIMAL.getType());
+                jsonObject.add(VALUE, new JsonPrimitive((BigDecimal) value));
+            } else if(value instanceof BigInteger) {
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.BIG_INTEGER.getType());
+                jsonObject.add(VALUE, new JsonPrimitive((BigInteger) value));
+            } else if(value instanceof Boolean) {
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.BOOLEAN.getType());
+                jsonObject.add(VALUE, new JsonPrimitive((Boolean) value));
+            } else if(value instanceof Byte) {
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.BYTE.getType());
+                jsonObject.add(VALUE, new JsonPrimitive((Byte) value));
+            } else if(value instanceof Character) {
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.CHARACTER.getType());
+                jsonObject.add(VALUE, new JsonPrimitive((Character) value));
+            } else if(value instanceof Double) {
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.DOUBLE.getType());
+                jsonObject.add(VALUE, new JsonPrimitive((Double) value));
+            } else if(value instanceof Float) {
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.FLOAT.getType());
+                jsonObject.add(VALUE, new JsonPrimitive((Float) value));
+            } else if(value instanceof Integer) {
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.INT.getType());
+                jsonObject.add(VALUE, new JsonPrimitive((Integer) value));
+            } else if(value instanceof Long) {
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.LONG.getType());
+                jsonObject.add(VALUE, new JsonPrimitive((Long) value));
+            } else if(value instanceof Short) {
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.SHORT.getType());
+                jsonObject.add(VALUE, new JsonPrimitive((Short) value));
+            } else if(value instanceof String) {
+                jsonObject.addProperty(TYPE, JsonPrimitiveTypes.STRING.getType());
+                jsonObject.add(VALUE, new JsonPrimitive((String) value));
+            } else {
+               throw new IllegalArgumentException("Can not handle value of type '" + value.getClass() + "'");
+            }
+            array.add(jsonObject);
+        });
+        return array;
+    }
+
+    protected Map<String, Serializable> getAsMap(final JsonObject jsonObject, final String jsonElementName) {
+        final Map<String, Serializable> result = new HashMap<>();
+        final JsonArray array = getElement(jsonObject, jsonElementName).getAsJsonArray();
+        array.forEach(i -> {
+            final JsonObject element = i.getAsJsonObject();
+            final String key = getStringElement(element, NAME);
+            final JsonPrimitive value = getElement(element, VALUE).getAsJsonPrimitive();
+            final String typeName = getStringElement(element, TYPE);
+            final JsonPrimitiveTypes type = JsonPrimitiveTypes.ofType(typeName);
+            result.put(key, type.getValueOfElement(value));
+        });
+        return result;
     }
 
     protected String getStringElement(final JsonObject jsonObject, final String jsonElementName) {

--- a/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/codec/encoders/CreateControllerCommandEncoder.java
+++ b/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/codec/encoders/CreateControllerCommandEncoder.java
@@ -26,6 +26,7 @@ import static dev.rico.internal.remoting.legacy.communication.CommandConstants.C
 import static dev.rico.internal.remoting.legacy.communication.CommandConstants.CREATE_CONTROLLER_COMMAND_ID;
 import static dev.rico.internal.remoting.legacy.communication.CommandConstants.ID;
 import static dev.rico.internal.remoting.legacy.communication.CommandConstants.NAME;
+import static dev.rico.internal.remoting.legacy.communication.CommandConstants.PARAMS;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 @API(since = "0.x", status = INTERNAL)
@@ -37,6 +38,7 @@ public class CreateControllerCommandEncoder extends AbstractCommandTranscoder<Cr
         final JsonObject jsonCommand = new JsonObject();
         jsonCommand.addProperty(CONTROLLER_ID, command.getParentControllerId());
         jsonCommand.addProperty(NAME, command.getControllerName());
+        jsonCommand.add(PARAMS, convertToJsonObject(command.getParameters()));
         jsonCommand.addProperty(ID, CREATE_CONTROLLER_COMMAND_ID);
         return jsonCommand;
     }
@@ -50,6 +52,9 @@ public class CreateControllerCommandEncoder extends AbstractCommandTranscoder<Cr
                 command.setParentControllerId(getStringElement(jsonObject, CONTROLLER_ID));
             }
             command.setControllerName(getStringElement(jsonObject, NAME));
+            if(jsonObject.has(PARAMS) && !isElementJsonNull(jsonObject, PARAMS)) {
+                command.setParameters(getAsMap(jsonObject, PARAMS));
+            }
             return command;
         } catch (final Exception ex) {
             throw new JsonParseException("Illegal JSON detected", ex);

--- a/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/codec/encoders/CreatePresentationModelCommandEncoder.java
+++ b/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/codec/encoders/CreatePresentationModelCommandEncoder.java
@@ -36,7 +36,7 @@ import static dev.rico.internal.remoting.legacy.communication.CommandConstants.I
 import static dev.rico.internal.remoting.legacy.communication.CommandConstants.NAME;
 import static dev.rico.internal.remoting.legacy.communication.CommandConstants.PM_ATTRIBUTES;
 import static dev.rico.internal.remoting.legacy.communication.CommandConstants.PM_ID;
-import static dev.rico.internal.remoting.legacy.communication.CommandConstants.PM_TYPE;
+import static dev.rico.internal.remoting.legacy.communication.CommandConstants.TYPE;
 import static dev.rico.internal.remoting.legacy.communication.CommandConstants.VALUE;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
@@ -49,7 +49,7 @@ public class CreatePresentationModelCommandEncoder extends AbstractCommandTransc
 
         final JsonObject jsonCommand = new JsonObject();
         jsonCommand.addProperty(PM_ID, command.getPmId());
-        jsonCommand.addProperty(PM_TYPE, command.getPmType());
+        jsonCommand.addProperty(TYPE, command.getPmType());
 
         final JsonArray jsonArray = new JsonArray();
         for (final Map<String, Object> attribute : command.getAttributes()) {
@@ -73,7 +73,7 @@ public class CreatePresentationModelCommandEncoder extends AbstractCommandTransc
             final CreatePresentationModelCommand command = new CreatePresentationModelCommand();
 
             command.setPmId(getStringElement(jsonObject, PM_ID));
-            command.setPmType(getStringElement(jsonObject, PM_TYPE));
+            command.setPmType(getStringElement(jsonObject, TYPE));
             command.setClientSideOnly(false);
 
             final JsonArray jsonArray = jsonObject.getAsJsonArray(PM_ATTRIBUTES);

--- a/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/commands/CreateControllerCommand.java
+++ b/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/commands/CreateControllerCommand.java
@@ -21,6 +21,12 @@ import dev.rico.internal.remoting.legacy.communication.Command;
 import dev.rico.internal.remoting.legacy.communication.CommandConstants;
 import org.apiguardian.api.API;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 @API(since = "0.x", status = INTERNAL)
@@ -30,8 +36,11 @@ public final class CreateControllerCommand extends Command {
 
     private String controllerName;
 
+    private Map<String, Serializable> parameters;
+
     public CreateControllerCommand() {
         super(CommandConstants.CREATE_CONTROLLER_COMMAND_ID);
+        parameters = new HashMap<>();
     }
 
     public String getParentControllerId() {
@@ -49,5 +58,13 @@ public final class CreateControllerCommand extends Command {
     public void setControllerName(final String controllerName) {
         Assert.requireNonBlank(controllerName, "controllerName");
         this.controllerName = controllerName;
+    }
+
+    public Map<String, Serializable> getParameters() {
+        return Optional.ofNullable(parameters).orElse(Collections.emptyMap());
+    }
+
+    public void setParameters(final Map<String, Serializable> parameters) {
+        this.parameters = parameters;
     }
 }

--- a/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/legacy/communication/CommandConstants.java
+++ b/remoting/rico-remoting-common/src/main/java/dev/rico/internal/remoting/legacy/communication/CommandConstants.java
@@ -42,7 +42,7 @@ public interface CommandConstants {
     String ATTRIBUTE_ID = "a_id";
     String PM_ID = "p_id";
     String CONTROLLER_ID = "c_id";
-    String PM_TYPE = "t";
+    String TYPE = "t";
     String NAME = "n";
     String VALUE = "v";
     String PARAMS = "p";

--- a/remoting/rico-remoting-server/src/main/java/dev/rico/internal/server/remoting/context/ServerRemotingContext.java
+++ b/remoting/rico-remoting-server/src/main/java/dev/rico/internal/server/remoting/context/ServerRemotingContext.java
@@ -64,6 +64,7 @@ import org.apiguardian.api.API;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -188,7 +189,7 @@ public class ServerRemotingContext {
                 registerCommand(registry, DestroyContextCommand.class, (c) -> onDestroyContext());
                 registerCommand(registry, CreateControllerCommand.class, (createControllerCommand) -> {
                     Assert.requireNonNull(createControllerCommand, "createControllerCommand");
-                    onCreateController(createControllerCommand.getControllerName(), createControllerCommand.getParentControllerId());
+                    onCreateController(createControllerCommand.getControllerName(), createControllerCommand.getParentControllerId(), createControllerCommand.getParameters());
                 });
                 registerCommand(registry, DestroyControllerCommand.class, (destroyControllerCommand) -> {
                     Assert.requireNonNull(destroyControllerCommand, "destroyControllerCommand");
@@ -218,15 +219,16 @@ public class ServerRemotingContext {
         onDestroyCallback.accept(this);
     }
 
-    private void onCreateController(final String controllerName, final String parentControllerId) {
+    private void onCreateController(final String controllerName, final String parentControllerId, final Map<String, Serializable> parameters) {
         Assert.requireNonBlank(controllerName, "controllerName");
 
         if (platformBeanRepository == null) {
             throw new IllegalStateException("An action was called before the init-command was sent.");
         }
-        final InternalAttributesBean bean = platformBeanRepository.getInternalAttributesBean();
-        final String controllerId = controllerHandler.createController(controllerName, parentControllerId);
+        final String controllerId = controllerHandler.createController(controllerName, parentControllerId, parameters);
 
+
+        final InternalAttributesBean bean = platformBeanRepository.getInternalAttributesBean();
         bean.setControllerId(controllerId);
         Object model = controllerHandler.getControllerModel(controllerId);
         if (model != null) {

--- a/remoting/rico-remoting-server/src/main/java/dev/rico/internal/server/remoting/controller/ControllerHandler.java
+++ b/remoting/rico-remoting-server/src/main/java/dev/rico/internal/server/remoting/controller/ControllerHandler.java
@@ -19,6 +19,7 @@ package dev.rico.internal.server.remoting.controller;
 import dev.rico.internal.core.Assert;
 import dev.rico.internal.core.ReflectionHelper;
 import dev.rico.internal.core.context.ContextManagerImpl;
+import dev.rico.internal.core.lang.StringUtils;
 import dev.rico.internal.remoting.BeanRepository;
 import dev.rico.internal.remoting.Converters;
 import dev.rico.internal.server.beans.PostConstructInterceptor;
@@ -32,11 +33,13 @@ import dev.rico.server.remoting.PreChildDestroyed;
 import dev.rico.server.remoting.RemotingAction;
 import dev.rico.server.remoting.RemotingModel;
 import dev.rico.remoting.converter.ValueConverterException;
+import dev.rico.server.remoting.RemotingValue;
 import dev.rico.server.spi.components.ManagedBeanFactory;
 import org.apiguardian.api.API;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -99,11 +102,11 @@ public class ControllerHandler {
         return models.get(id);
     }
 
-    public String createController(final String name, final String parentControllerId) {
+    public String createController(final String name, final String parentControllerId, final Map<String, Serializable> parameters) {
         Assert.requireNonBlank(name, "name");
         final Class<?> controllerClass = controllerRepository.getControllerClassForName(name);
 
-        if(controllerClass == null) {
+        if (controllerClass == null) {
             throw new ControllerCreationException("Can not find controller class for name " + name);
         }
 
@@ -112,15 +115,16 @@ public class ControllerHandler {
             @Override
             public void intercept(final Object controller) {
                 attachModel(id, controller);
-                if(parentControllerId != null) {
+                if (parentControllerId != null) {
                     attachParent(id, controller, parentControllerId);
                 }
+                injectValues(controller, parameters);
             }
         });
         controllers.put(id, instance);
         controllerClassMapping.put(id, controllerClass);
 
-        if(parentControllerId != null) {
+        if (parentControllerId != null) {
             final Object parentController = controllers.get(parentControllerId);
             Assert.requireNonNull(parentController, "parentController");
             firePostChildCreated(parentController, instance);
@@ -135,8 +139,8 @@ public class ControllerHandler {
         Assert.requireNonBlank(id, "id");
 
         final List<String> childControllerIds = parentChildRelations.remove(id);
-        if(childControllerIds != null && !childControllerIds.isEmpty()) {
-            for(final String childControllerId : childControllerIds) {
+        if (childControllerIds != null && !childControllerIds.isEmpty()) {
+            for (final String childControllerId : childControllerIds) {
                 destroyController(childControllerId);
             }
         }
@@ -145,7 +149,7 @@ public class ControllerHandler {
         Assert.requireNonNull(controller, "controller");
 
         final String parentControllerId = childToParentRelations.remove(id);
-        if(parentControllerId != null) {
+        if (parentControllerId != null) {
             final Object parentController = controllers.get(parentControllerId);
             Assert.requireNonNull(parentController, "parentController");
             firePreChildDestroyed(parentController, controller);
@@ -162,7 +166,7 @@ public class ControllerHandler {
 
     public void destroyAllControllers() {
         final List<String> currentControllerIds = new ArrayList<>(getAllControllerIds());
-        for(String id : currentControllerIds) {
+        for (String id : currentControllerIds) {
             destroyController(id);
         }
     }
@@ -173,9 +177,9 @@ public class ControllerHandler {
 
         final List<Method> allMethods = ReflectionHelper.getInheritedDeclaredMethods(parentController.getClass());
 
-        for(final Method method : allMethods) {
-            if(method.isAnnotationPresent(PostChildCreated.class)) {
-                if(method.getParameters()[0].getType().isAssignableFrom(childController.getClass())) {
+        for (final Method method : allMethods) {
+            if (method.isAnnotationPresent(PostChildCreated.class)) {
+                if (method.getParameters()[0].getType().isAssignableFrom(childController.getClass())) {
                     ReflectionHelper.invokePrivileged(method, parentController, childController);
                 }
             }
@@ -185,13 +189,34 @@ public class ControllerHandler {
     private void firePreChildDestroyed(final Object parentController, final Object childController) {
         final List<Method> allMethods = ReflectionHelper.getInheritedDeclaredMethods(parentController.getClass());
 
-        for(final Method method : allMethods) {
-            if(method.isAnnotationPresent(PreChildDestroyed.class)) {
-                if(method.getParameters()[0].getType().isAssignableFrom(childController.getClass())) {
+        for (final Method method : allMethods) {
+            if (method.isAnnotationPresent(PreChildDestroyed.class)) {
+                if (method.getParameters()[0].getType().isAssignableFrom(childController.getClass())) {
                     ReflectionHelper.invokePrivileged(method, parentController, childController);
                 }
             }
         }
+    }
+
+    private void injectValues(final Object controller, final Map<String, Serializable> parameters) {
+        Assert.requireNonNull(parameters, "parameters");
+        Assert.requireNonNull(controller, "controller");
+
+        final List<Field> allFields = ReflectionHelper.getInheritedDeclaredFields(controller.getClass());
+        allFields.stream()
+                .forEach(f -> {
+                    ReflectionHelper.getAnnotationOrMetaAnnotation(f, RemotingValue.class).ifPresent(annotation -> {
+                        final String name = StringUtils.nonEmpty(annotation.value()).orElse(f.getName());
+                        if (parameters.containsKey(name)) {
+                            ReflectionHelper.setPrivileged(f, controller, parameters.get(name));
+                        } else {
+                            if (!annotation.optional()) {
+                                throw new IllegalStateException("No value defined for configuration value '" + name + "' in controller '" + controller.getClass() + "'");
+                            }
+                        }
+                    });
+
+                });
     }
 
     private void attachModel(final String controllerId, final Object controller) {
@@ -239,11 +264,11 @@ public class ControllerHandler {
             final Object parentController = controllers.get(parentControllerId);
             Assert.requireNonNull(parentController, "parentController");
 
-            if(!parentField.getType().isAssignableFrom(parentController.getClass())) {
+            if (!parentField.getType().isAssignableFrom(parentController.getClass())) {
                 throw new RuntimeException("Parent controller in " + controller.getClass() + " defined of wrong type. Should be " + parentController.getClass());
             }
             ReflectionHelper.setPrivileged(parentField, controller, parentController);
-            if(parentChildRelations.get(parentControllerId) == null) {
+            if (parentChildRelations.get(parentControllerId) == null) {
                 parentChildRelations.put(parentControllerId, new ArrayList<String>());
             }
             parentChildRelations.get(parentControllerId).add(controllerId);
@@ -264,23 +289,23 @@ public class ControllerHandler {
         final Subscription controllerActionContextSubscription = ContextManagerImpl.getInstance()
                 .addThreadContext(CONTROLLER_ACTION_CONTEXT, actionName);
         try {
-            if(controller == null) {
+            if (controller == null) {
                 throw new InvokeActionException("No controller for id " + controllerId + " found");
             }
 
-            if(controllerClass == null) {
+            if (controllerClass == null) {
                 throw new InvokeActionException("No controllerClass for id " + controllerId + " found");
             }
             final Method actionMethod = getActionMethod(controllerClass, actionName);
-            if(actionMethod == null) {
+            if (actionMethod == null) {
                 throw new InvokeActionException("No actionMethod with name " + actionName + " in controller class " + ControllerUtils.getControllerName(controllerClass) + " found");
             }
             final List<Object> args = getArgs(actionMethod, params);
             LOG.debug("Will call {} action for controller {} ({}.{}) with {} params.", actionName, controllerId, controllerClass, ControllerUtils.getActionMethodName(actionMethod), args.size());
-            if(LOG.isTraceEnabled()) {
+            if (LOG.isTraceEnabled()) {
                 int index = 1;
-                for(final Object param : args) {
-                    if(param != null) {
+                for (final Object param : args) {
+                    if (param != null) {
                         LOG.trace("Action param {}: {} with type {} is called with value \"{}\" and type {}", index, actionMethod.getParameters()[index - 1].getName(), actionMethod.getParameters()[index - 1].getType().getSimpleName(), param, param.getClass());
                     } else {
                         LOG.trace("Action param {}: {} with type {} is called with value null", index, actionMethod.getParameters()[index - 1].getName(), actionMethod.getParameters()[index - 1].getType().getSimpleName());
@@ -291,7 +316,7 @@ public class ControllerHandler {
             try {
                 ReflectionHelper.invokePrivileged(actionMethod, controller, args.toArray());
             } catch (final RuntimeException e) {
-                if(e.getCause() instanceof InvocationTargetException) {
+                if (e.getCause() instanceof InvocationTargetException) {
                     final InvocationTargetException invocationTargetException = (InvocationTargetException) e.getCause();
                     final Throwable internalException = invocationTargetException.getCause();
                     actionErrorHandler.handle(internalException, controller, ControllerUtils.getControllerName(controllerClass), actionName);
@@ -299,7 +324,7 @@ public class ControllerHandler {
                 throw e;
             }
         } catch (final InvokeActionException e) {
-          throw e;
+            throw e;
         } catch (final Exception e) {
             throw new InvokeActionException("Can not call action '" + actionName + "'", e);
         } finally {
@@ -325,16 +350,16 @@ public class ControllerHandler {
                     }
                 }
             }
-            if(!params.containsKey(paramName)) {
+            if (!params.containsKey(paramName)) {
                 throw new IllegalArgumentException("No value for param " + paramName + " specified!");
             }
             final Object value = params.get(paramName);
             final Class<?> type = method.getParameters()[i].getType();
-            if(value != null) {
+            if (value != null) {
                 LOG.trace("Param check of value {} with type {} for param with type {}", value, value.getClass(), type);
                 args.add(converters.getConverter(type).convertFromRemoting(value));
             } else {
-                if(type.isPrimitive()) {
+                if (type.isPrimitive()) {
                     throw new IllegalArgumentException("Can not use 'null' for primitive type of parameter '" + paramName + "'");
                 }
                 args.add(null);


### PR DESCRIPTION
Additional functionality to define parameters for a controller.
A client can now specify initial parameters for a controller when creating a controller proxy. Such parameters will automatically be injected in a new controller instance on the server side (see @RemotingValue) before any @PostContruct method is called.

By doing so controllers with initial data (like detail controllers in a master-detail-view) can be created in a much better way. Until now the client needed to specify the data (like the id of the item that should be shown) after the controller was created. Therefore the model was initial empty and an empty view was displayed. By defining initial parameters (like the id of an item)  the controller can already fill the model in any @PostContruct method and therefore the client can show a full view directly once it is created.