### PR TITLE
Logo do not use ANSI codes on windows

### DIFF
--- a/base/rico-core/src/main/java/dev/rico/internal/core/OsUtil.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/OsUtil.java
@@ -1,0 +1,10 @@
+package dev.rico.internal.core;
+
+public class OsUtil {
+
+    public static boolean isWindows() {
+        String operSys = System.getProperty(RicoConstants.OS_NAME).toLowerCase();
+        return (operSys.contains(RicoConstants.WIN));
+    }
+
+}

--- a/base/rico-core/src/main/java/dev/rico/internal/core/OsUtil.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/OsUtil.java
@@ -1,7 +1,35 @@
+/*
+ * Copyright 2018-2019 Karakun AG.
+ * Copyright 2015-2018 Canoo Engineering AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.rico.internal.core;
 
+import org.apiguardian.api.API;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+/**
+ * Utility class for OS related functionalities.
+ */
+@API(since = "0.x", status = INTERNAL)
 public class OsUtil {
 
+    /**
+     * Returns {@code true} if we are on windows.
+     * @return
+     */
     public static boolean isWindows() {
         String operSys = System.getProperty(RicoConstants.OS_NAME).toLowerCase();
         return (operSys.contains(RicoConstants.WIN));

--- a/base/rico-core/src/main/java/dev/rico/internal/core/RicoConstants.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/RicoConstants.java
@@ -52,4 +52,8 @@ public interface RicoConstants {
     String THREAD_GROUP_NAME = "Rico executors";
 
     String PLATFORM_VERSION_CONTEXT = "platform.version";
+
+    String OS_NAME = "os.name";
+
+    String WIN = "win";
 }

--- a/base/rico-core/src/main/java/dev/rico/internal/core/ansi/AnsiOut.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/ansi/AnsiOut.java
@@ -45,6 +45,10 @@ public interface AnsiOut {
     String ANSI_CYAN_BACKGROUND = "\u001B[46m";
     String ANSI_WHITE_BACKGROUND = "\u001B[47m";
 
+    /**
+     * Returns true if the current platform supports ANSI codes
+     * @return true if the current platform supports ANSI codes
+     */
     static boolean isSupported() {
         return !OsUtil.isWindows();
     }

--- a/base/rico-core/src/main/java/dev/rico/internal/core/ansi/AnsiOut.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/ansi/AnsiOut.java
@@ -16,6 +16,7 @@
  */
 package dev.rico.internal.core.ansi;
 
+import dev.rico.internal.core.OsUtil;
 import org.apiguardian.api.API;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
@@ -43,4 +44,9 @@ public interface AnsiOut {
     String ANSI_PURPLE_BACKGROUND = "\u001B[45m";
     String ANSI_CYAN_BACKGROUND = "\u001B[46m";
     String ANSI_WHITE_BACKGROUND = "\u001B[47m";
+
+    static boolean isSupported() {
+        return !OsUtil.isWindows();
+    }
+
 }

--- a/base/rico-core/src/main/java/dev/rico/internal/core/ansi/PlatformLogo.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/ansi/PlatformLogo.java
@@ -25,25 +25,24 @@ import java.util.Optional;
  */
 public class PlatformLogo {
 
-
     public static void printLogo() {
         final String version = PlatformVersion.getVersion();
         final String versionString = Optional.of(version).map(v -> "Version " + version + " | ").orElse("");
         final String versionEndSuffix = "                       ".substring(Math.min(20,versionString.length()));
 
-        final String strokeColor = AnsiOut.ANSI_BLUE;
-        final String textColor = AnsiOut.ANSI_RED;
-        final String borderColor = AnsiOut.ANSI_GREEN;
+        final String strokeColor = getIfAnsiSupported(AnsiOut.ANSI_BLUE);
+        final String textColor = getIfAnsiSupported(AnsiOut.ANSI_RED);
+        final String borderColor = getIfAnsiSupported(AnsiOut.ANSI_GREEN);
 
 
-        final String borderStart = AnsiOut.ANSI_BOLD + borderColor;
-        final String borderEnd = AnsiOut.ANSI_RESET;
+        final String borderStart = getIfAnsiSupported(AnsiOut.ANSI_BOLD) + borderColor;
+        final String borderEnd = getIfAnsiSupported(AnsiOut.ANSI_RESET);
         final String borderPipe = borderStart + "|" + borderEnd;
-        final String logoStart = AnsiOut.ANSI_BOLD + strokeColor;
+        final String logoStart = getIfAnsiSupported(AnsiOut.ANSI_BOLD) + strokeColor;
         final String textStart = textColor;
-        final String textEnd = AnsiOut.ANSI_RESET;
-        final String boldTextStart = AnsiOut.ANSI_BOLD + textColor;
-        final String boldTextEnd = AnsiOut.ANSI_RESET;
+        final String textEnd = getIfAnsiSupported(AnsiOut.ANSI_RESET);
+        final String boldTextStart = getIfAnsiSupported(AnsiOut.ANSI_BOLD) + textColor;
+        final String boldTextEnd = getIfAnsiSupported(AnsiOut.ANSI_RESET);
 
         System.out.println("");
         System.out.println("  " + borderStart + "____________________________________________________________________________________" + borderEnd);
@@ -58,6 +57,13 @@ public class PlatformLogo {
         System.out.println("");
     }
 
+    private static String getIfAnsiSupported(final String ansiCode) {
+        if(AnsiOut.isSupported()) {
+            return ansiCode;
+        } else {
+            return "";
+        }
+    }
 
     public static void main(String[] args) {
         printLogo();

--- a/base/rico-core/src/main/java/dev/rico/internal/core/ansi/PlatformLogo.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/ansi/PlatformLogo.java
@@ -17,14 +17,18 @@
 package dev.rico.internal.core.ansi;
 
 import dev.rico.internal.core.PlatformVersion;
+import org.apiguardian.api.API;
 
 import java.util.Optional;
 
-/**
- * Created by hendrikebbers on 23.01.18.
- */
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+@API(since = "0.x", status = INTERNAL)
 public class PlatformLogo {
 
+    /**
+     * Prints the Rico logo
+     */
     public static void printLogo() {
         final String version = PlatformVersion.getVersion();
         final String versionString = Optional.of(version).map(v -> "Version " + version + " | ").orElse("");
@@ -57,6 +61,11 @@ public class PlatformLogo {
         System.out.println("");
     }
 
+    /**
+     * Returns the given ansi code if ANSI commands are supported or an empty String
+     * @param ansiCode the ansi code
+     * @return ansi code or empty string
+     */
     private static String getIfAnsiSupported(final String ansiCode) {
         if(AnsiOut.isSupported()) {
             return ansiCode;


### PR DESCRIPTION
On windows the logo really looks ugly since the ANSI code is printed instead of interpreted by the shell.