### PR TITLE
fix:(rico-data)Implement missing mapper method toBean

### DIFF
--- a/incubation/rico-data/src/main/java/dev/rico/internal/server/data/mapping/BeanConverter.java
+++ b/incubation/rico-data/src/main/java/dev/rico/internal/server/data/mapping/BeanConverter.java
@@ -22,8 +22,8 @@ import java.io.Serializable;
 
 public interface BeanConverter<ID extends Serializable, B, E extends DataWithId<ID>> {
 
-    E enrichtEntityByBean(E entity, B bean);
+    E enrichEntityByBean(E entity, B bean);
 
-    B enrichtBeanByEntity(B bean, E entity);
+    B enrichBeanByEntity(B bean, E entity);
 
 }

--- a/incubation/rico-data/src/main/java/dev/rico/internal/server/data/mapping/BeanMapperImpl.java
+++ b/incubation/rico-data/src/main/java/dev/rico/internal/server/data/mapping/BeanMapperImpl.java
@@ -94,16 +94,14 @@ public class BeanMapperImpl implements BeanMapper {
 
         final Class<E> entityClass = (Class<E>) entity.getClass();
 
-        B bean = beanManager.create(beanClass);
-
-        Map<Class<?>, BeanConverter> converterMap = converters.computeIfAbsent(entityClass, c -> new HashMap<>());
-        BeanConverter beanConverter = converterMap.get(beanClass);
+        final Map<Class<?>, BeanConverter> converterMap = converters.computeIfAbsent(entityClass, c -> new HashMap<>());
+        final BeanConverter beanConverter = converterMap.get(beanClass);
 
         if (beanConverter == null) {
             throw new IllegalStateException("No converter for " + beanClass.getSimpleName() + " to " + entityClass + " registered!");
         }
 
-        bean = (B) beanConverter.enrichBeanByEntity(bean, entity);
+        final B bean = (B) beanConverter.enrichBeanByEntity(beanManager.create(beanClass), entity);
 
         beanToIdMapper.computeIfAbsent(bean, b -> new HashMap<>()).put(entityClass, entity.getId());
 

--- a/incubation/rico-data/src/main/java/dev/rico/internal/server/data/mapping/BeanMapperImpl.java
+++ b/incubation/rico-data/src/main/java/dev/rico/internal/server/data/mapping/BeanMapperImpl.java
@@ -73,7 +73,7 @@ public class BeanMapperImpl implements BeanMapper {
         final ID id = entity.getId();
         final BeanConverter<ID, B, E> converter = getConverter(entityClass, beanClass);
         addMapping(bean, entityClass, id);
-        return converter.enrichtBeanByEntity(bean, entity);
+        return converter.enrichBeanByEntity(bean, entity);
     }
 
     @Override
@@ -84,7 +84,7 @@ public class BeanMapperImpl implements BeanMapper {
         final E entity = Optional.ofNullable(getEntityIdForBean(bean, entityClass))
                 .map(id -> service.findById(id))
                 .orElse(service.createNewInstance());
-        return converter.enrichtEntityByBean(entity, bean);
+        return converter.enrichEntityByBean(entity, bean);
     }
 
     @Override
@@ -103,7 +103,7 @@ public class BeanMapperImpl implements BeanMapper {
             throw new IllegalStateException("No converter for " + beanClass.getSimpleName() + " to " + entityClass + " registered!");
         }
 
-        bean = (B) beanConverter.enrichtBeanByEntity(bean, entity);
+        bean = (B) beanConverter.enrichBeanByEntity(bean, entity);
 
         beanToIdMapper.computeIfAbsent(bean, b -> new HashMap<>()).put(entityClass, entity.getId());
 

--- a/integration-tests/integration-tests/src/test/java/dev/rico/integrationtests/remoting/PropertyControllerTest.java
+++ b/integration-tests/integration-tests/src/test/java/dev/rico/integrationtests/remoting/PropertyControllerTest.java
@@ -100,7 +100,7 @@ public class PropertyControllerTest extends AbstractRemotingIntegrationTest {
         }
     }
 
-    @Test(dataProvider = ENDPOINTS_DATAPROVIDER, description = "Test if all property values are snychronized")
+    @Test(dataProvider = ENDPOINTS_DATAPROVIDER, description = "Test if all property values are synchronized")
     public void testPropertyValueSet(String containerType, String endpoint) {
         try {
             ClientContext context = connect(endpoint);


### PR DESCRIPTION
Implement missing mapper method in rico-data
also fix typos; one in an API method name, but as part of "incubation" package