### PR TITLE
DownloadInputStream: support for indeterminate downloads

### DIFF
--- a/base/rico-core/src/main/java/dev/rico/core/http/DownloadInputStream.java
+++ b/base/rico-core/src/main/java/dev/rico/core/http/DownloadInputStream.java
@@ -17,6 +17,7 @@ public abstract class DownloadInputStream extends InputStream {
 
     /**
      * Returns a {@link CompletableFuture} to access the hash once the download is done
+     *
      * @return a {@link CompletableFuture} to access the hash once the download is done
      */
     public abstract CompletableFuture<String> getHash();
@@ -25,19 +26,22 @@ public abstract class DownloadInputStream extends InputStream {
      * Sets the chunk size that is used to check for updates of listeners. While the stream is used listeners
      * (see {@link #addDownloadPercentageListener(Consumer)}) will be called several times. The chunk size defines
      * after what byte count the listener will be called again.
+     *
      * @param updateChunkSize the new chunk size
      */
     public abstract void setUpdateChunkSize(final long updateChunkSize);
 
-        /**
-         * Adds a listener that is triggered once the download starts
-         * @param listener the listener
-         * @return the subscription
-         */
+    /**
+     * Adds a listener that is triggered once the download starts
+     *
+     * @param listener the listener
+     * @return the subscription
+     */
     public abstract Subscription addDownloadStartListener(final Consumer<Long> listener);
 
     /**
      * Adds a listener that is triggered automatically several times while the download is running.
+     *
      * @param listener the listener
      * @return the subscription
      */
@@ -45,6 +49,7 @@ public abstract class DownloadInputStream extends InputStream {
 
     /**
      * Adds a listener that is triggered once the download is done
+     *
      * @param listener the listener
      * @return the subscription
      */
@@ -53,6 +58,7 @@ public abstract class DownloadInputStream extends InputStream {
     /**
      * Adds a listener that is triggered if the download ends with an error
      * (like a {@link java.io.IOException} while reading from the stream)
+     *
      * @param listener the listener
      * @return the subscription
      */
@@ -60,12 +66,14 @@ public abstract class DownloadInputStream extends InputStream {
 
     /**
      * Returns the type of the download
+     *
      * @return the type of the download
      */
     public abstract DownloadType getDownloadType();
 
     /**
      * Returns the count of bytes that was already downloaded.
+     *
      * @return count of bytes that was already downloaded
      */
     public abstract long getDownloaded();
@@ -73,6 +81,7 @@ public abstract class DownloadInputStream extends InputStream {
     /**
      * Returns the data size of the complete download (if that is known), otherwise -1. If the size is not known the
      * download is defined as indeterminate (see {@link #getDownloadType()}).
+     *
      * @return the data size of the complete download (if that is known), otherwise -1.
      */
     public abstract long getDataSize();

--- a/base/rico-core/src/main/java/dev/rico/core/http/DownloadInputStream.java
+++ b/base/rico-core/src/main/java/dev/rico/core/http/DownloadInputStream.java
@@ -10,7 +10,7 @@ import java.util.function.Consumer;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 /**
- * A {@link InputStream} that adds functionallity to handle downloads.
+ * A {@link InputStream} that adds functionality to handle downloads.
  */
 @API(since = "0.x", status = EXPERIMENTAL)
 public abstract class DownloadInputStream extends InputStream {
@@ -41,4 +41,31 @@ public abstract class DownloadInputStream extends InputStream {
      * @return the subscription
      */
     public abstract Subscription addDownloadDoneListener(final Consumer<Long> listener);
+
+    /**
+     * Adds a listener that is triggered if the download ends with an error
+     * (like a {@link java.io.IOException} while reading from the stream)
+     * @param listener the listener
+     * @return the subscription
+     */
+    public abstract Subscription addDownloadErrorListener(final Consumer<Exception> listener);
+
+    /**
+     * Returns the type of the download
+     * @return the type of the download
+     */
+    public abstract DownloadType getDownloadType();
+
+    /**
+     * Returns the count of bytes that was already downloaded.
+     * @return count of bytes that was already downloaded
+     */
+    public abstract long getDownloaded();
+
+    /**
+     * Returns the data size of the complete download (if that is known), otherwise -1. If the size is not known the
+     * download is defined as indeterminate (see {@link #getDownloadType()}).
+     * @return the data size of the complete download (if that is known), otherwise -1.
+     */
+    public abstract long getDataSize();
 }

--- a/base/rico-core/src/main/java/dev/rico/core/http/DownloadInputStream.java
+++ b/base/rico-core/src/main/java/dev/rico/core/http/DownloadInputStream.java
@@ -22,10 +22,18 @@ public abstract class DownloadInputStream extends InputStream {
     public abstract CompletableFuture<String> getHash();
 
     /**
-     * Adds a listener that is triggered once the download starts
-     * @param listener the listener
-     * @return the subscription
+     * Sets the chunk size that is used to check for updates of listeners. While the stream is used listeners
+     * (see {@link #addDownloadPercentageListener(Consumer)}) will be called several times. The chunk size defines
+     * after what byte count the listener will be called again.
+     * @param updateChunkSize the new chunk size
      */
+    public abstract void setUpdateChunkSize(final long updateChunkSize);
+
+        /**
+         * Adds a listener that is triggered once the download starts
+         * @param listener the listener
+         * @return the subscription
+         */
     public abstract Subscription addDownloadStartListener(final Consumer<Long> listener);
 
     /**

--- a/base/rico-core/src/main/java/dev/rico/core/http/DownloadType.java
+++ b/base/rico-core/src/main/java/dev/rico/core/http/DownloadType.java
@@ -1,0 +1,10 @@
+package dev.rico.core.http;
+
+/**
+ * Defines if a download (see {@link DownloadInputStream}) knows the final size of the download
+ * ({@link #NORMAL}) or not ({@link #INDETERMINATE})
+ */
+public enum DownloadType {
+
+    INDETERMINATE, NORMAL;
+}

--- a/base/rico-core/src/main/java/dev/rico/core/http/DownloadType.java
+++ b/base/rico-core/src/main/java/dev/rico/core/http/DownloadType.java
@@ -1,8 +1,8 @@
 package dev.rico.core.http;
 
 /**
- * Defines if a download (see {@link DownloadInputStream}) knows the final size of the download
- * ({@link #NORMAL}) or not ({@link #INDETERMINATE})
+ * Defines if a download (see {@link DownloadInputStream}) has a determined size
+ * ({@link #NORMAL}) or not ({@link #INDETERMINATE}).
  */
 public enum DownloadType {
 

--- a/base/rico-core/src/main/java/dev/rico/internal/core/http/DownloadInputStreamImpl.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/http/DownloadInputStreamImpl.java
@@ -2,6 +2,7 @@ package dev.rico.internal.core.http;
 
 import dev.rico.core.functional.Subscription;
 import dev.rico.core.http.DownloadInputStream;
+import dev.rico.core.http.DownloadType;
 import dev.rico.core.http.HttpResponse;
 import dev.rico.internal.core.Assert;
 import org.slf4j.Logger;
@@ -12,6 +13,7 @@ import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
@@ -29,6 +31,8 @@ public class DownloadInputStreamImpl extends DownloadInputStream {
 
     private final List<Consumer<Long>> downloadDoneListeners;
 
+    private final List<Consumer<Exception>> onErrorListeners;
+
     private final Executor updateExecutor;
 
     private final DigestInputStream wrappedStream;
@@ -43,16 +47,29 @@ public class DownloadInputStreamImpl extends DownloadInputStream {
 
     private final AtomicBoolean firstRead;
 
+    private final DownloadType downloadType;
+
     public DownloadInputStreamImpl(final InputStream inputStream, final long dataSize, final Executor updateExecutor) {
         this.updateExecutor = Assert.requireNonNull(updateExecutor, "updateExecutor");
-        this.dataSize = dataSize;
+        this.dataSize = dataSize > 0 ? dataSize : -1;
+        if (dataSize > 0) {
+            downloadType = DownloadType.NORMAL;
+        } else {
+            downloadType = DownloadType.INDETERMINATE;
+        }
         this.downloaded = new AtomicLong(0);
         this.lastUpdateSize = new AtomicLong(0);
         this.firstRead = new AtomicBoolean(true);
         this.downloadPercentageListeners = new CopyOnWriteArrayList<>();
         this.downloadStartListeners = new CopyOnWriteArrayList<>();
         this.downloadDoneListeners = new CopyOnWriteArrayList<>();
-        this.updateChunkSize = dataSize / 100;
+        this.onErrorListeners = new CopyOnWriteArrayList<>();
+        if (dataSize > 0) {
+            this.updateChunkSize = dataSize / 1000;
+        } else {
+            this.updateChunkSize = 1000;
+        }
+
         try {
             this.wrappedStream = ConnectionUtils.createMD5HashStream(inputStream);
         } catch (NoSuchAlgorithmException e) {
@@ -68,40 +85,76 @@ public class DownloadInputStreamImpl extends DownloadInputStream {
         return future;
     }
 
+    public DownloadType getDownloadType() {
+        return downloadType;
+    }
+
     @Override
     public int read(final byte[] b, final int off, final int len) throws IOException {
-        final int count = super.read(b, off, len);
-        if(count < 0) {
-            onDone();
+        try {
+            final int count = super.read(b, off, len);
+            if (count < 0) {
+                onDone();
+            }
+            return count;
+        } catch (final Exception e) {
+            try {
+                onError(e);
+            } finally {
+                throw e;
+            }
         }
-        return count;
     }
 
     @Override
     public void close() throws IOException {
-        super.close();
+        try {
+            super.close();
+        } catch (final Exception e) {
+            try {
+                onError(e);
+            } finally {
+                throw e;
+            }
+        }
         onDone();
     }
 
     public int read() throws IOException {
-        if (firstRead.get()) {
-            onStart();
-            firstRead.set(false);
+        try {
+            if (firstRead.get()) {
+                onStart();
+                firstRead.set(false);
+            }
+            final int value = wrappedStream.read();
+            if (value >= 0) {
+                update(1);
+            }
+            return value;
+        } catch (final Exception e) {
+            try {
+                onError(e);
+            } finally {
+                throw e;
+            }
         }
-        final int value = wrappedStream.read();
-        if(value >= 0) {
-            update(1);
-        }
-        return value;
     }
 
     @Override
     public int available() throws IOException {
-        final int available = super.available();
-        if (available < 0) {
-            onDone();
+        try {
+            final int available = super.available();
+            if (available < 0) {
+                onDone();
+            }
+            return available;
+        } catch (final Exception e) {
+            try {
+                onError(e);
+            } finally {
+                throw e;
+            }
         }
-        return available;
     }
 
     public Subscription addDownloadStartListener(final Consumer<Long> listener) {
@@ -122,9 +175,14 @@ public class DownloadInputStreamImpl extends DownloadInputStream {
         return () -> downloadDoneListeners.remove(listener);
     }
 
+    public Subscription addDownloadErrorListener(final Consumer<Exception> listener) {
+        Assert.requireNonNull(listener, "listener");
+        onErrorListeners.add(listener);
+        return () -> onErrorListeners.remove(listener);
+    }
+
     private void onDone() {
         LOG.trace("Download of size {} done", dataSize);
-
         updateExecutor.execute(() -> downloadDoneListeners.forEach(l -> l.accept(dataSize)));
     }
 
@@ -133,17 +191,34 @@ public class DownloadInputStreamImpl extends DownloadInputStream {
         updateExecutor.execute(() -> downloadStartListeners.forEach(l -> l.accept(dataSize)));
     }
 
+    private void onError(final Exception e) {
+        LOG.trace("Downloaded of size {} started", dataSize);
+        updateExecutor.execute(() -> onErrorListeners.forEach(l -> l.accept(e)));
+    }
+
     private synchronized void update(final int len) {
         final long currentSize = downloaded.addAndGet(len);
         if (lastUpdateSize.get() + updateChunkSize <= currentSize) {
             LOG.trace("Downloaded {} bytes of {}", currentSize, dataSize);
+            lastUpdateSize.set(currentSize);
             updateExecutor.execute(() -> {
-                lastUpdateSize.set(currentSize);
-                final double percentageDone = (((double) currentSize) / ((double) dataSize / 100.0)) / 100.0;
-                LOG.trace("Downloaded {} %", percentageDone);
-                downloadPercentageListeners.forEach(l -> l.accept(percentageDone));
+                if(Objects.equals(downloadType, DownloadType.NORMAL)) {
+                    final double percentageDone = (((double) currentSize) / ((double) dataSize / 100.0)) / 100.0;
+                    LOG.trace("Downloaded {} %", percentageDone);
+                    downloadPercentageListeners.forEach(l -> l.accept(percentageDone));
+                } else {
+                    downloadPercentageListeners.forEach(l -> l.accept(-1d));
+                }
             });
         }
+    }
+
+    public long getDownloaded() {
+        return downloaded.get();
+    }
+
+    public long getDataSize() {
+        return dataSize;
     }
 
     public static DownloadInputStreamImpl map(final HttpResponse<InputStream> response, final Executor executor) {


### PR DESCRIPTION
If a server endpoint do not provide any information for the size of a download the DownloadInputStream is now defined as indeterminate and provide some special functionality and better performance for that case.