### PR TITLE
build: pin travis-build config to use trusty for JDK8 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: required
 language: java
 jdk: oraclejdk8


### PR DESCRIPTION
As Oracle Java 8 is not support after Travis updates in travis default config, thus this config pins it to "trusty"