### PR TITLE
rename Tuple -> Pair

### DIFF
--- a/base/rico-core/src/main/java/dev/rico/core/lang/Pair.java
+++ b/base/rico-core/src/main/java/dev/rico/core/lang/Pair.java
@@ -16,36 +16,36 @@
  */
 package dev.rico.core.lang;
 
-import dev.rico.internal.core.lang.DefaultTuple;
+import dev.rico.internal.core.lang.DefaultPair;
 
 /**
- * Defines a tuple that holds a key-value pair
+ * Defines a pair that holds a key-value pair.
+ *
  * @param <K> type of the key
  * @param <V> type of the value
  */
-public interface Tuple<K, V> {
+public interface Pair<K, V> {
 
     /**
-     * Returns the key
      * @return the key
      */
     K getKey();
 
     /**
-     * Returns the value
      * @return the value
      */
     V getValue();
 
     /**
-     * Generates a new {@link Tuple} based on the given key and value
-     * @param key the key
+     * Generates a new {@link Pair} based on the given key and value.
+     *
+     * @param key   the key
      * @param value the value
-     * @param <A> type of the key
-     * @param <B> type of the value
-     * @return the tuple
+     * @param <A>   type of the key
+     * @param <B>   type of the value
+     * @return the pair
      */
-    static <A, B> Tuple<A, B> of(A key, B value) {
-        return new DefaultTuple<>(key, value);
+    static <A, B> Pair<A, B> of(A key, B value) {
+        return new DefaultPair<>(key, value);
     }
 }

--- a/base/rico-core/src/main/java/dev/rico/core/lang/StringPair.java
+++ b/base/rico-core/src/main/java/dev/rico/core/lang/StringPair.java
@@ -20,10 +20,11 @@ import dev.rico.internal.core.lang.DefaultStringPair;
 /**
  * Defines a key-value pair both of which are strings
  */
-public interface StringPair extends Tuple<String, String> {
+public interface StringPair extends Pair<String, String> {
 
     /**
-     * Generates a new {@link StringPair} based on the given key and value
+     * Generates a new {@link StringPair} based on the given key and value.
+     *
      * @param key the key
      * @param value the value
      * @return the pair

--- a/base/rico-core/src/main/java/dev/rico/internal/core/lang/DefaultPair.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/lang/DefaultPair.java
@@ -16,22 +16,22 @@
  */
 package dev.rico.internal.core.lang;
 
-import dev.rico.core.lang.Tuple;
+import dev.rico.core.lang.Pair;
 
 import java.util.Objects;
 
 /**
- * Default implementation of {@link Tuple}
+ * Default implementation of {@link Pair}
  * @param <K> type of the key
  * @param <V> type of the value
  */
-public class DefaultTuple<K, V> implements Tuple<K, V> {
+public class DefaultPair<K, V> implements Pair<K, V> {
 
     private final K key;
 
     private final V value;
 
-    public DefaultTuple(final K key, final V value) {
+    public DefaultPair(final K key, final V value) {
         this.key = key;
         this.value = value;
     }
@@ -48,7 +48,7 @@ public class DefaultTuple<K, V> implements Tuple<K, V> {
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        final DefaultTuple<?, ?> tuple = (DefaultTuple<?, ?>) o;
+        final DefaultPair<?, ?> tuple = (DefaultPair<?, ?>) o;
         return Objects.equals(key, tuple.key) &&
                 Objects.equals(value, tuple.value);
     }

--- a/base/rico-core/src/main/java/dev/rico/internal/core/lang/DefaultStringPair.java
+++ b/base/rico-core/src/main/java/dev/rico/internal/core/lang/DefaultStringPair.java
@@ -18,9 +18,9 @@ package dev.rico.internal.core.lang;
 import dev.rico.core.lang.StringPair;
 
 /**
- * Default implementation of {@link StringPair}
+ * Default implementation of {@link StringPair}.
  */
-public class DefaultStringPair extends DefaultTuple<String, String> implements StringPair {
+public class DefaultStringPair extends DefaultPair<String, String> implements StringPair {
     public DefaultStringPair(String key, String value) {
         super(key, value);
     }


### PR DESCRIPTION
renamed the public `Tuple` interface to `Pair`.
